### PR TITLE
[Draft] Add IP lookup functionality

### DIFF
--- a/cli/ip.go
+++ b/cli/ip.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"flag"
+	"github.com/erikkn/klaabu/klaabu"
+	"log"
+	"net"
+	"os"
+)
+
+func ipCommand() {
+	get := flag.NewFlagSet("ip", flag.ExitOnError)
+	schemaFileName := get.String("schema", "schema.kml", "(Optional) Schema file path (defaults to ./schema.kml)")
+	err := get.Parse(os.Args[2:])
+
+	rawIp := get.Arg(0)
+
+	if err != nil || len(os.Args) < 3 {
+		log.Printf("Usage: klaabu ip [OPTIONS] IP_ADDRESS \n\n Subcommands: \n")
+		get.PrintDefaults()
+		os.Exit(1)
+	}
+
+	schema, err := klaabu.LoadSchemaFromKmlFile(*schemaFileName)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	ip := net.ParseIP(rawIp)
+	if ip == nil {
+		log.Fatalf("Couldn't parse ip.")
+	}
+
+	matches := schema.SearchIp(ip)
+	log.Println(matches)
+}

--- a/cli/ip.go
+++ b/cli/ip.go
@@ -13,10 +13,8 @@ func ipCommand() {
 	schemaFileName := get.String("schema", "schema.kml", "(Optional) Schema file path (defaults to ./schema.kml)")
 	err := get.Parse(os.Args[2:])
 
-	rawIp := get.Arg(0)
-
 	if err != nil || len(os.Args) < 3 {
-		log.Printf("Usage: klaabu ip [OPTIONS] IP_ADDRESS \n\n Subcommands: \n")
+		log.Printf("Usage: klaabu ip [OPTIONS] CIDR \n\n Subcommands: \n")
 		get.PrintDefaults()
 		os.Exit(1)
 	}
@@ -26,11 +24,12 @@ func ipCommand() {
 		log.Fatalln(err)
 	}
 
-	ip := net.ParseIP(rawIp)
-	if ip == nil {
-		log.Fatalf("Couldn't parse ip.")
+	rawIpNet := get.Arg(0)
+	_, ipnet, err := net.ParseCIDR(rawIpNet)
+	if err != nil {
+		log.Fatalf("Couldn't parse CIDR. For raw IPv4, stick /32 after? Error: %v", err)
 	}
 
-	matches := schema.SearchIp(ip)
+	matches := schema.SearchNet(ipnet)
 	log.Println(matches)
 }

--- a/cli/main.go
+++ b/cli/main.go
@@ -11,6 +11,7 @@ var commands = map[string]func(){
 	"fmt":              fmtCommand,
 	"get":              getCommand,
 	"init":             initCommand,
+	"ip":               ipCommand,
 	"space":            spaceCommand,
 	"validate":         validateCommand,
 	"version":          versionCommand,

--- a/klaabu/prefix.go
+++ b/klaabu/prefix.go
@@ -79,16 +79,16 @@ func (p *Prefix) PrefixById(id string) *Prefix {
 	return nil
 }
 
-// SearchIp find the most specific prefix that contains the given IP address.
+// SearchNet find the most specific prefix that contains the given IP address.
 // It returns the list of aliases for that prefix.
-func (p *Prefix) SearchIp(ip net.IP) []string {
+func (p *Prefix) SearchNet(needle *net.IPNet) []string {
 	//log.Print(p)
 	_, ipnet, err := net.ParseCIDR(string(p.Cidr))
 	if err != nil {
 		return []string{"err"}
 	}
 	//log.Print(ipnet)
-	if ipnet.Contains(ip) {
+	if iputil.NetContainsNet(ipnet, needle) {
 		// If there are no children, or none contains the ip, return this prefix.
 		// If there are children, with exactly one containing the ip, recurse.
 		// If multiple contains the ip (which is odd-ish, except range whatever), stop here and return all.
@@ -98,7 +98,7 @@ func (p *Prefix) SearchIp(ip net.IP) []string {
 			if err != nil {
 				return []string{"errr"}
 			}
-			if cnet.Contains(ip) {
+			if iputil.NetContainsNet(cnet, needle) {
 				cs = append(cs, child)
 			}
 		}
@@ -106,7 +106,7 @@ func (p *Prefix) SearchIp(ip net.IP) []string {
 			return p.Aliases
 		}
 		if len(cs) == 1 {
-			return cs[0].SearchIp(ip)
+			return cs[0].SearchNet(needle)
 		}
 		return []string{"TODO multiple"}
 	}

--- a/klaabu/prefix.go
+++ b/klaabu/prefix.go
@@ -3,6 +3,8 @@ package klaabu
 import (
 	"fmt"
 	"github.com/erikkn/klaabu/klaabu/iputil"
+	//"log"
+	"net"
 	"sort"
 )
 
@@ -75,6 +77,40 @@ func (p *Prefix) PrefixById(id string) *Prefix {
 	}
 
 	return nil
+}
+
+// SearchIp find the most specific prefix that contains the given IP address.
+// It returns the list of aliases for that prefix.
+func (p *Prefix) SearchIp(ip net.IP) []string {
+	//log.Print(p)
+	_, ipnet, err := net.ParseCIDR(string(p.Cidr))
+	if err != nil {
+		return []string{"err"}
+	}
+	//log.Print(ipnet)
+	if ipnet.Contains(ip) {
+		// If there are no children, or none contains the ip, return this prefix.
+		// If there are children, with exactly one containing the ip, recurse.
+		// If multiple contains the ip (which is odd-ish, except range whatever), stop here and return all.
+		cs := []*Prefix{}
+		for _, child := range p.Children {
+			_, cnet, err := net.ParseCIDR(string(child.Cidr))
+			if err != nil {
+				return []string{"errr"}
+			}
+			if cnet.Contains(ip) {
+				cs = append(cs, child)
+			}
+		}
+		if len(cs) == 0 {
+			return p.Aliases
+		}
+		if len(cs) == 1 {
+			return cs[0].SearchIp(ip)
+		}
+		return []string{"TODO multiple"}
+	}
+	return []string{"not-found"}
 }
 
 // FindPrefixesByLabelNamesValues fetches every Prefix that has all the 'key' and 'value' label pairs set that are passed through 'l'. Every item of slice 'l' contains a key&value pair following the 'key=value' notation. This Function starts traversing down the tree from whatever value 'c' is.

--- a/klaabu/schema.go
+++ b/klaabu/schema.go
@@ -26,8 +26,8 @@ func (s *Schema) PrefixById(id string) *Prefix {
 	return s.Root.PrefixById(id)
 }
 
-func (s *Schema) SearchIp(ip net.IP) []string {
-	return s.Root.SearchIp(ip)
+func (s *Schema) SearchNet(ipnet *net.IPNet) []string {
+	return s.Root.SearchNet(ipnet)
 }
 
 // Validate checks if you are stupid or not.

--- a/klaabu/schema.go
+++ b/klaabu/schema.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"net"
 )
 
 // Schema is the Klaabu schema.
@@ -23,6 +24,10 @@ func NewSchema(labels map[string]string) *Schema {
 
 func (s *Schema) PrefixById(id string) *Prefix {
 	return s.Root.PrefixById(id)
+}
+
+func (s *Schema) SearchIp(ip net.IP) []string {
+	return s.Root.SearchIp(ip)
 }
 
 // Validate checks if you are stupid or not.


### PR DESCRIPTION
## Context

This is useful for example to translate a list of IPs to their named counterparts. For example:

```
for ip in $(cat iplist.txt | sort -u); do RES=$(./cli ip -schema /path/to/klaabu-schema/schema.kml $ip 2>&1); echo $ip $RES; done > ipmap.txt

```

### Changes

Plumb IP lookup on the prefix tree, up to cli.

## Checklist
- [ ] I have considered the impact of this change and added a [Change Classification](
https://transferwise.atlassian.net/wiki/spaces/EKB/pages/1401189673/Change+Classifications+and+Expectations) Label (`change:standard`, `change:impactful`, `change:emergency`)
- [ ] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
